### PR TITLE
unescape url entries to save complex filter and version munging

### DIFF
--- a/corpus/dir/file.html
+++ b/corpus/dir/file.html
@@ -14,6 +14,7 @@
 <LI><A HREF="foo-1.00.tar.bz2">foo-1.00.tar.bz2</A>
 <LI><A HREF="foo-1.00.tar.gz">foo-1.00.tar.gz</A>
 <LI><A HREF="foo-1.00.tar.xz">foo-1.00.tar.xz</A>
+<LI><A HREF='foo%2D1%2E00%2Etgz'>foo-1.00.tgz</A>
 <LI><A HREF="foo-1.00.zip">foo-1.00.zip</A>
 </UL>
 </BODY>

--- a/corpus/dir/http.html
+++ b/corpus/dir/http.html
@@ -25,6 +25,7 @@ table { width:100%%; }
   <tr><td class='name'><a href='/corpus/dist/foo-1.00.tar.bz2'>foo-1.00.tar.bz2</a></td><td class='size'>301</td><td class='type'>text/plain</td><td class='mtime'>Fri, 20 Jan 2017 00:43:29 GMT</td></tr>
   <tr><td class='name'><a href='/corpus/dist/foo-1.00.tar.gz'>foo-1.00.tar.gz</a></td><td class='size'>261</td><td class='type'>application/x-gzip</td><td class='mtime'>Fri, 20 Jan 2017 11:22:51 GMT</td></tr>
   <tr><td class='name'><a href='/corpus/dist/foo-1.00.tar.xz'>foo-1.00.tar.xz</a></td><td class='size'>296</td><td class='type'>text/plain</td><td class='mtime'>Fri, 20 Jan 2017 00:43:29 GMT</td></tr>
+  <tr><td class='name'><a href='/corpus/dist/foo%2D1%2E00%2Etgz'>foo%2D1%2E00%2Etgz</a></td><td class='size'>584</td><td class='type'>application/x-gzip</td><td class='mtime'>Fri, 20 Jan 2017 11:23:15 GMT</td></tr>
   <tr><td class='name'><a href='/corpus/dist/foo-1.00.zip'>foo-1.00.zip</a></td><td class='size'>584</td><td class='type'>application/zip</td><td class='mtime'>Fri, 20 Jan 2017 11:23:15 GMT</td></tr>
 </table>
 <hr />

--- a/corpus/dir/http_rel.html
+++ b/corpus/dir/http_rel.html
@@ -25,6 +25,7 @@ table { width:100%%; }
   <tr><td class='name'><a href='foo-1.00.tar.bz2'>foo-1.00.tar.bz2</a></td><td class='size'>301</td><td class='type'>text/plain</td><td class='mtime'>Fri, 20 Jan 2017 00:43:29 GMT</td></tr>
   <tr><td class='name'><a href='foo-1.00.tar.gz'>foo-1.00.tar.gz</a></td><td class='size'>261</td><td class='type'>application/x-gzip</td><td class='mtime'>Fri, 20 Jan 2017 11:22:51 GMT</td></tr>
   <tr><td class='name'><a href='foo-1.00.tar.xz'>foo-1.00.tar.xz</a></td><td class='size'>296</td><td class='type'>text/plain</td><td class='mtime'>Fri, 20 Jan 2017 00:43:29 GMT</td></tr>
+  <tr><td class='name'><a href='foo%2D1%2E00%2Etgz'>foo-1.00.tgz</a></td><td class='size'>584</td><td class='type'>application/x-gzip</td><td class='mtime'>Fri, 20 Jan 2017 11:23:15 GMT</td></tr>
   <tr><td class='name'><a href='foo-1.00.zip'>foo-1.00.zip</a></td><td class='size'>584</td><td class='type'>application/zip</td><td class='mtime'>Fri, 20 Jan 2017 11:23:15 GMT</td></tr>
 </table>
 <hr />

--- a/lib/Alien/Build/Plugin/Decode/HTML.pm
+++ b/lib/Alien/Build/Plugin/Decode/HTML.pm
@@ -29,6 +29,7 @@ sub init
 
   $meta->add_requires('share' => 'HTML::LinkExtor' => 0);
   $meta->add_requires('share' => 'URI' => 0);
+  $meta->add_requires('share' => 'URI::Escape' => 0);
   
   $meta->register_hook( decode => sub {
     my(undef, $res) = @_;
@@ -54,8 +55,8 @@ sub init
         my $path = $url->path;
         $path =~ s{/$}{}; # work around for Perl 5.8.7- gh#8
         push @list, {
-          filename => File::Basename::basename($path),
-          url      => $url->as_string,
+          filename => URI::Escape::uri_unescape(File::Basename::basename($path)),
+          url      => URI::Escape::uri_unescape("$url"),
         };
       }
     });

--- a/t/alien_build_plugin_decode_html.t
+++ b/t/alien_build_plugin_decode_html.t
@@ -10,9 +10,9 @@ subtest 'updates requires' => sub {
   my $plugin = Alien::Build::Plugin::Decode::HTML->new;
 
   my($build,$meta) = build_blank_alien_build;
-  
+
   $plugin->init($meta);
-  
+
   is( $build->requires('share')->{'HTML::LinkExtor'}, 0 );
   is( $build->requires('share')->{'URI'}, 0 );
 
@@ -25,7 +25,7 @@ subtest 'decode' => sub {
   my $plugin = Alien::Build::Plugin::Decode::HTML->new;
 
   my($build,$meta) = build_blank_alien_build;
-  
+
   $plugin->init($meta);
 
   eval { $build->load_requires('share') };
@@ -45,7 +45,7 @@ subtest 'decode' => sub {
         hash {
           field type => 'list';
           field list => array {
-            foreach my $filename (qw( foo-1.00 foo-1.00.tar foo-1.00.tar.Z foo-1.00.tar.bz2 foo-1.00.tar.gz foo-1.00.tar.xz foo-1.00.zip))
+            foreach my $filename (qw( foo-1.00 foo-1.00.tar foo-1.00.tar.Z foo-1.00.tar.bz2 foo-1.00.tar.gz foo-1.00.tar.xz foo-1.00.tgz foo-1.00.zip))
             {
               item hash {
                 field filename => $filename;


### PR DESCRIPTION
Simply unescape URL and filename while decoding to ensure that simple `filter` and `version` such as below are possible.

## expected behaviour

The following `filter` and `version` pick matching URIs
```perl
  filter  => qr/^package-([\d\.]+\w?).tar\.gz$/,
  version => qr/^package-([\d\.]+\w?).tar\.gz$/,
```

## actual behaviour

The list contains hash entries like:
```perl
  filename => "package%2D1%2E1%2E%2Dtar%2Dgz",
  url => "http://localhost/package%2D1%2E1%2E%2Dtar%2Dgz"
```